### PR TITLE
OCQL contempla gli extendend attribute filters

### DIFF
--- a/classes/extendedattributefilters/pivot.php
+++ b/classes/extendedattributefilters/pivot.php
@@ -1,0 +1,33 @@
+<?php
+
+use Opencontent\Opendata\Api\SearchResultDecoratorInterface;
+use Opencontent\Opendata\Api\Values\SearchResults;
+use Opencontent\Opendata\Api\QueryLanguage\EzFind\SearchResultInfo;
+
+// $queryParamList['facet.pivot'] = 'meta_owner_id_si,extra_project_name_s,attr_ore_lavorative_effettive_s';
+// $queryParamList['facet.pivot.mincount'] = 0;
+
+class OpendataPivotExtendedAttributeFilter implements eZFindExtendedAttributeFilterInterface, SearchResultDecoratorInterface
+{
+	public function filterQueryParams( array $queryParams, array $filterParams )
+    {
+    	if (isset($filterParams['facet'])){
+            $queryParams['facet.pivot'] = is_array($filterParams['facet']) ? implode(',', $filterParams['facet']) : $filterParams['facet'];
+
+            if (isset($filterParams['mincount'])){
+                $queryParams['facet.pivot.mincount'] = (int)$filterParams['mincount'];
+            }
+        }        
+        
+        return $queryParams;
+    }
+
+    public function decorate(SearchResults $searchResults, $rawResults)
+    {
+        $searchExtra = SearchResultInfo::fromEzfSearchResultInfo($rawResults['SearchExtras']);
+        $result = $searchExtra->attribute('result');
+        if (isset($result['facet_counts']['facet_pivot'])) {
+            $searchResults->pivot = $result['facet_counts']['facet_pivot'];
+        }        
+    }
+}

--- a/classes/extendedattributefilters/range.php
+++ b/classes/extendedattributefilters/range.php
@@ -1,0 +1,60 @@
+<?php
+
+use Opencontent\Opendata\Api\SearchResultDecoratorInterface;
+use Opencontent\Opendata\Api\Values\SearchResults;
+use Opencontent\Opendata\Api\QueryLanguage\EzFind\SearchResultInfo;
+
+class OpendataRangeExtendedAttributeFilter implements eZFindExtendedAttributeFilterInterface, SearchResultDecoratorInterface
+{
+    public function filterQueryParams( array $queryParamList, array $filterParams )
+    {
+        if ( !empty( $filterParams['field'])
+             && !empty( $filterParams['start'])
+             && !empty( $filterParams['end'])
+             && !empty( $filterParams['gap'])
+        ){
+            $fieldName = $filterParams['field'];
+
+            $perFieldRangePrefix = 'f.' . $fieldName . '.facet.range';
+
+            $queryParamList['facet.range'] = $fieldName;
+
+            $queryParamList[$perFieldRangePrefix . '.start'] = $this->formatValue($fieldName, $filterParams['start']);
+            $queryParamList[$perFieldRangePrefix . '.end'] = $this->formatValue($fieldName, $filterParams['end']);
+            $queryParamList[$perFieldRangePrefix . '.gap'] = '+' . trim(ltrim($filterParams['gap'], '+'));
+
+            if( !empty( $filterParams['hardend'])){
+                $queryParamList[$perFieldRangePrefix . '.hardend'] = $filterParams['hardend'];
+            }
+
+            if( !empty( $filterParams['include'])){
+                $queryParamList[$perFieldRangePrefix . '.include'] = $filterParams['include'];
+            }
+
+            if( !empty( $filterParams['other'])){
+                $queryParamList[$perFieldRangePrefix . '.other'] = $filterParams['other'];
+            }
+        }
+
+        return $queryParamList;
+    }
+
+    private function formatValue($fieldName, $value)
+    {
+        if (strpos($fieldName, '_dt') !== false){
+            $time = new \DateTime( $value, new \DateTimeZone('UTC') );
+            return ezfSolrDocumentFieldBase::convertTimestampToDate( $time->format('U') );
+        }
+            
+        return $value;     
+    }
+
+    public function decorate(SearchResults $searchResults, $rawResults)
+    {
+        $searchExtra = SearchResultInfo::fromEzfSearchResultInfo($rawResults['SearchExtras']);
+        $result = $searchExtra->attribute('result');
+        if (isset($result['facet_counts']['facet_ranges'])) {
+            $searchResults->facet_range = $result['facet_counts']['facet_ranges'];
+        }
+    }
+}

--- a/classes/extendedattributefilters/stats.php
+++ b/classes/extendedattributefilters/stats.php
@@ -1,0 +1,62 @@
+<?php
+
+use Opencontent\Opendata\Api\SearchResultDecoratorInterface;
+use Opencontent\Opendata\Api\Values\SearchResults;
+use Opencontent\Opendata\Api\QueryLanguage\EzFind\SearchResultInfo;
+
+/*
+ * $queryParamList['stats'] = 'true';
+ * $queryParamList['stats.field'] = 'meta_section_id_si';
+ * $queryParamList['stats.facet'] = ['meta_owner_id_si', 'extra_project_name_s'];
+ *
+ *  fetch( 'ezfind', 'search', hash(
+ *        'extended_attribute_filter', array(
+ *            hash(
+ *             'id', 'stats',
+ *             'params', hash(
+ *                 'field', 'meta_section_id_si',
+ *                 'facet', array('meta_owner_id_si', 'extra_project_name_s')
+ *             )
+ *            )
+ *        )
+ *  ))
+ *
+ */
+
+class OpendataStatsExtendedAttributeFilter implements eZFindExtendedAttributeFilterInterface, SearchResultDecoratorInterface
+{
+    public function filterQueryParams(array $queryParams, array $filterParams)
+    {
+        if (!isset($filterParams['field'])) {
+            throw new Exception('Missing filter parameter "field" in stats');
+        }
+
+        $fieldName = eZSolr::getFieldName($filterParams['field']);
+        $queryParams['stats'] = 'true';
+        $queryParams['stats.field'] = $fieldName;
+
+        if (isset($filterParams['facet'])) {
+            $facetsParams = $filterParams['facet'];
+            if (!is_array($facetsParams)) {
+                $facetsParams = array($facetsParams);
+            }
+            $facetNameList = array();
+            foreach ($facetsParams as $facetParam) {
+                $facetName = eZSolr::getFieldName($facetParam, false, 'facet');
+                $facetNameList[] = $facetName;
+            }
+            $queryParams['stats.facet'] = $facetNameList;
+        }
+
+        return $queryParams;
+    }
+
+    public function decorate(SearchResults $searchResults, $rawResults)
+    {
+        $searchExtra = SearchResultInfo::fromEzfSearchResultInfo($rawResults['SearchExtras']);
+        $result = $searchExtra->attribute('result');
+        if (isset($result['stats'])) {
+            $searchResults->stats = $result['stats'];
+        }
+    }
+}

--- a/design/standard/templates/opendata/console.tpl
+++ b/design/standard/templates/opendata/console.tpl
@@ -87,6 +87,17 @@
         </div>
     </div>
 
+    <div class="row">
+        <div class="col-sm-6">
+            <h3>eZFind Query</h3>
+            <pre id="ezfind-query"></pre>
+        </div>
+        <div class="col-sm-6">
+            <h3>Extra results</h3>
+            <pre id="facets-results"></pre>
+        </div>
+    </div>
+
     <hr />
 
     <h2>Classi</h2>
@@ -109,6 +120,9 @@
     </form>
 
     <div id="class-result" style="margin: 20px 0"></div>
+
+
+    {def $extendedAttributeFilters = ezini('ExtendedAttributeFilters', 'FiltersList', 'ezfind.ini')}
 
     <script>
     $(function() {ldelim}
@@ -167,7 +181,9 @@
             'queryString': $('#query-string'),
             'queryAnalysis': $('#query-analysis'),
             'results': $('#search-results'),
-            'geoResults': $('#geo-results')
+            'geoResults': $('#geo-results'),
+            'ezfindQuery': $('#ezfind-query'),
+            'facetsResults': $('#facets-results')
         };
 
         var $errors = $('#errors');
@@ -350,11 +366,20 @@
             });
             $searchContainers.queryAnalysis.html( content );
             console.log(data.ezfind);
+            $searchContainers.ezfindQuery.html(JSON.stringify(data.ezfind, null, 4));
         };
 
         var loadSearchResults = function(url,data){
             $(icon).removeClass('fa-cog fa-spin');
-
+            $searchContainers.facetsResults.html('Facets: ' + JSON.stringify(data.facets, null, 4));
+            if (data.ranges)
+                $searchContainers.facetsResults.append("\nRanges: " + JSON.stringify(data.ranges, null, 4));
+            {/literal}
+            {foreach $extendedAttributeFilters as $filter => $class}
+            if (data.{$filter})
+                $searchContainers.facetsResults.append("\n{$filter}: " + JSON.stringify(data.{$filter}, null, 4));
+            {/foreach}
+            {literal}
             var results = data.searchHits;
             var searchQuery = url.replace(searchEndpoint,'');
             var content = '<strong>API /content</strong>:<br/> <a href="'+url+'"><code>'+decodeURIComponent(searchQuery)+'</code></a>';
@@ -523,6 +548,19 @@
 
 </div>
 
+
+{*fetch( 'ezfind', 'search', hash(
+       'limit', 1,
+       'extended_attribute_filter', array(
+           hash(
+            'id', 'stats',
+            'params', hash(
+                'field', 'meta_section_id_si',
+                'facet', array('meta_owner_id_si', 'extra_project_name_s')
+            )
+           )
+       )
+)).SearchExtras|attribute(show,4)*}
 
 </body>
 </html>

--- a/lib/ocopendata/src/Opencontent/Opendata/Api/ContentSearch.php
+++ b/lib/ocopendata/src/Opencontent/Opendata/Api/ContentSearch.php
@@ -2,18 +2,8 @@
 
 namespace Opencontent\Opendata\Api;
 
-use Opencontent\Opendata\Api\Gateway\FileSystem;
-use Opencontent\Opendata\Api\Gateway\SolrStorage;
-use Opencontent\Opendata\Api\QueryLanguage\EzFind\QueryBuilder;
-use Opencontent\Opendata\Api\Values\Content;
-use Opencontent\Opendata\Api\Values\ContentData;
-use Opencontent\Opendata\Api\Values\ExtraData;
-use Opencontent\Opendata\Api\Values\Metadata;
-use Opencontent\Opendata\Api\Values\SearchResults;
-use Exception;
-use eZSolr;
-use ezfSearchResultInfo;
-use ArrayObject;
+use Opencontent\Opendata\Api\QueryLanguage;
+use Opencontent\QueryLanguage\QueryBuilderInterface;
 
 class ContentSearch
 {
@@ -25,155 +15,31 @@ class ContentSearch
     /**
      * @var EnvironmentSettings
      */
-    private $currentEnvironmentSettings;
+    private $environmentSettings;
 
     /**
-     * @var QueryBuilder
+     * @var QueryBuilderInterface
      */
     private $queryBuilder;
 
+    /**
+     * @var SearchGateway
+     */
+    private $searchGateway;
+
     public function __construct()
     {
-        $this->queryBuilder = new QueryBuilder();
+        $this->queryBuilder = new QueryLanguage\EzFind\QueryBuilder();
+        $this->searchGateway = new QueryLanguage\EzFind\SearchGateway();
     }
 
     public function search($query, array $limitation = null)
     {
         $this->query = $query;
+        $this->searchGateway->setEnvironmentSettings($this->environmentSettings);
+        $this->searchGateway->setQueryBuilder($this->queryBuilder);
 
-        $queryObject = $this->queryBuilder->instanceQuery($query);
-        $ezFindQueryObject = $queryObject->convert();
-
-        if (!$ezFindQueryObject instanceof ArrayObject) {
-            throw new \RuntimeException("Query builder did not return a valid query");
-        }
-
-        $ezFindQueryObject = $this->currentEnvironmentSettings->filterQuery($ezFindQueryObject, $this->queryBuilder);
-        $ezFindQuery = $ezFindQueryObject->getArrayCopy();
-
-        //$ezFindQuery['Filter'][] = ezfSolrDocumentFieldBase::generateMetaFieldName('installation_id') . ':' . eZSolr::installationID();
-        if (is_array($limitation) && empty( $limitation )) {
-            $ezFindQuery['Filter'][] = \ezfSolrDocumentFieldBase::generateMetaFieldName('installation_id') . ':' . \eZSolr::installationID();
-        }
-        $ezFindQuery['Limitation'] = $limitation;
-        $ezFindQuery['AsObjects'] = false;
-        $ezFindQuery['FieldsToReturn'] = array(SolrStorage::getSolrIdentifier());
-
-        $filterFields = isset( $ezFindQuery['_filterFields'] ) ? $ezFindQuery['_filterFields'] : null;
-        unset( $ezFindQuery['_filterFields'] );
-
-        $filterLanguages = isset( $ezFindQuery['_filterLanguages'] ) ? $ezFindQuery['_filterLanguages'] : null;
-        unset( $ezFindQuery['_filterLanguages'] );
-
-        $solr = new eZSolr();
-        $rawResults = @$solr->search(
-            $ezFindQuery['_query'],
-            $ezFindQuery
-        );
-        if ($rawResults['SearchExtras'] instanceof ezfSearchResultInfo) {
-            if ($rawResults['SearchExtras']->attribute('hasError')) {
-                $error = $rawResults['SearchExtras']->attribute('error');
-                if (is_array($error)) {
-                    $error = (string)$error['msg'];
-                }
-                throw new \RuntimeException($error);
-            }
-        }
-
-        $searchResults = new SearchResults();
-        $filterFieldsResult = array();
-
-        if ($this->currentEnvironmentSettings->__get('debug') == true) {
-            $searchResults->query = array(
-                'string' => (string)$queryObject,
-                'eZFindQuery' => $ezFindQuery
-            );
-
-            if ($rawResults['SearchExtras'] instanceof ezfSearchResultInfo) {
-                $searchResults->query['responseHeader'] = $rawResults['SearchExtras']->attribute(
-                    'responseHeader'
-                );
-            }
-        } else {
-            $searchResults->query = (string)$queryObject;
-        }
-
-        $searchResults->totalCount = (int)$rawResults['SearchCount'];
-
-        if (( $ezFindQuery['SearchLimit'] + $ezFindQuery['SearchOffset'] ) < $searchResults->totalCount) {
-            $nextPageQuery = clone $queryObject;
-            $nextPageQuery->setParameter('offset', ( $ezFindQuery['SearchLimit'] + $ezFindQuery['SearchOffset'] ));
-            $searchResults->nextPageQuery = (string)$nextPageQuery;
-        }
-
-        $fileSystemGateway = new FileSystem();
-        $contentRepository = new ContentRepository();
-        $contentRepository->setEnvironment($this->currentEnvironmentSettings);
-
-        foreach ($rawResults['SearchResult'] as $resultItem) {
-            $id = isset( $resultItem['meta_id_si'] ) ? $resultItem['meta_id_si'] : isset( $resultItem['id_si'] ) ? $resultItem['id_si'] : $resultItem['id'];
-            try {
-                if (isset( $resultItem['data_map']['opendatastorage'] )) {
-                    $contentArray = $resultItem['data_map']['opendatastorage'];
-                    $content = new Content();
-                    $content->metadata = new Metadata((array)$contentArray['metadata']);
-                    $content->data = new ContentData((array)$contentArray['data']);
-                    if (isset( $contentArray['extradata'] )) {
-                        $content->extradata = new ExtraData((array)$contentArray['extradata']);
-                    }
-                } else {
-                    $content = $fileSystemGateway->loadContent((int)$id);
-                }
-
-                $ignorePolicies = false;
-                if (is_array($limitation)) {
-                    if (empty( $limitation ) || ( isset( $limitation['accessWord'] ) && $limitation['accessWord'] == 'yes' )) {
-                        $ignorePolicies = true;
-                    }
-                }
-                $content = $contentRepository->read($content, $ignorePolicies);
-
-                if ($filterFields !== null) {
-                    $this->filterFields($filterFieldsResult, $content, $filterFields, $filterLanguages);
-                } else {
-                    $searchResults->searchHits[] = $content;
-                }
-
-            } catch (Exception $e) {
-                $content = new Content();
-                $content->metadata = new Metadata(array('id' => $id));
-                $content->data = new ContentData(
-                    array(
-                        '_error' => $e->getMessage(),
-                        '_rawresult' => $resultItem
-                    )
-                );
-            }
-        }
-
-        if (isset( $ezFindQuery['Facet'] )
-            && is_array($ezFindQuery['Facet'])
-            && !empty( $ezFindQuery['Facet'] )
-            && $rawResults['SearchExtras'] instanceof ezfSearchResultInfo
-        ) {
-            $facets = array();
-            $facetResults = $rawResults['SearchExtras']->attribute('facet_fields');
-            foreach ($ezFindQuery['Facet'] as $index => $facetDefinition) {
-                $facetResult = $facetResults[$index];
-                $facets[] = array(
-                    'name' => $facetDefinition['name'],
-                    'data' => $facetResult['countList']
-                );
-            }
-            $searchResults->facets = $facets;
-        }
-
-        if ($filterFields !== null) {
-            return $filterFieldsResult;
-        }
-
-        return $this->currentEnvironmentSettings->filterSearchResult($searchResults, $ezFindQueryObject,
-            $this->queryBuilder);
+        return $this->searchGateway->search($query, $limitation);
     }
 
     /**
@@ -199,9 +65,19 @@ class ContentSearch
     /**
      * @return EnvironmentSettings
      */
+    public function getEnvironmentSettings()
+    {
+        return $this->environmentSettings;
+    }
+
+    /**
+     * Alias of method getEnvironmentSettings
+     *
+     * @return EnvironmentSettings
+     */
     public function getCurrentEnvironmentSettings()
     {
-        return $this->currentEnvironmentSettings;
+        return $this->environmentSettings;
     }
 
     /**
@@ -211,7 +87,7 @@ class ContentSearch
      */
     public function setEnvironment(EnvironmentSettings $environmentSettings)
     {
-        $this->currentEnvironmentSettings = $environmentSettings;
+        $this->environmentSettings = $environmentSettings;
 
         return $this;
     }
@@ -219,19 +95,19 @@ class ContentSearch
     /**
      * Alias of method setEnvironment
      *
-     * @param $currentEnvironmentSettings
+     * @param EnvironmentSettings $environmentSettings
      *
      * @return $this
      */
-    public function setCurrentEnvironmentSettings($currentEnvironmentSettings)
+    public function setCurrentEnvironmentSettings(EnvironmentSettings $environmentSettings)
     {
-        $this->currentEnvironmentSettings = $currentEnvironmentSettings;
+        $this->environmentSettings = $environmentSettings;
 
         return $this;
     }
 
     /**
-     * @return QueryBuilder
+     * @return QueryBuilderInterface
      */
     public function getQueryBuilder()
     {
@@ -239,103 +115,14 @@ class ContentSearch
     }
 
     /**
-     * @param QueryBuilder $queryBuilder
+     * @param QueryBuilderInterface $queryBuilder
      *
      * @return ContentSearch
      */
-    public function setQueryBuilder($queryBuilder)
+    public function setQueryBuilder(QueryBuilderInterface $queryBuilder)
     {
         $this->queryBuilder = $queryBuilder;
 
         return $this;
-    }
-
-    private function filterFields(&$filterFieldsResult, $content, array $fields, array $languages = null)
-    {
-        $data = array();
-
-        if (!$languages) {
-            $languages = $content['metadata']['languages'];
-        }
-
-        if (count($fields) == 1) {
-            reset($fields);
-            $key = key($fields);
-            if (!is_numeric($key)) {
-                $value = $fields[$key];
-                $this->filterHashedFields($filterFieldsResult, $content, $key, $value, $languages);
-                return;
-            }
-        }
-
-        foreach ($fields as $field) {
-            $key = $this->getFieldKey($field);
-            $value = $this->getFieldValue($content, $field, $languages);
-            if (count($fields) == 1 && !$key){
-                $data = $value;
-            }else{
-                if ($key){
-                    $data[$key] = $value;
-                }else{
-                    $data[] = $value;
-                }
-            }
-        }
-        $filterFieldsResult[] = $data;
-    }
-
-    private function filterHashedFields(&$filterFieldsResult, $content, $key, $value, array $languages = null)
-    {
-        $filterFieldsResult[$this->getFieldValue($content, $key, $languages)] = $this->getFieldValue($content, $value, $languages);
-    }
-
-    private function getFieldIdentifier($field)
-    {
-        $fieldNameParts = explode(' as ', $field);
-
-        return $fieldNameParts[0];
-    }
-
-    private function getFieldKey($field)
-    {
-        $fieldNameParts = explode(' as ', $field);
-
-        return isset( $fieldNameParts[1] ) ? $fieldNameParts[1] : null;
-    }
-
-    private function getFieldValue($content, $field, $languages)
-    {
-        if (count($languages) == 1) {
-            $item = self::getValueFromDottedKey($content, $this->getFieldIdentifier($field), $languages[0]);
-        } else {
-            $item = array();
-            foreach ($languages as $language) {
-                $item[$language] = self::getValueFromDottedKey($content, $this->getFieldIdentifier($field), $language);
-            }
-        }
-
-        return $item;
-    }
-
-    private static function getValueFromDottedKey($array, $key, $language, $default = null)
-    {
-        $value = $default;
-        foreach (explode('.', $key) as $segment) {
-            if (isset($array[$segment])){
-                $value = $array[$segment];
-                if (is_array($array[$segment])){
-                    $array = $array[$segment];
-                    if (isset($array[$language]) && is_array($array[$language])){
-                        $array = $array[$language];
-                    }
-                }
-            }else{
-                return $default;
-            }
-        }
-        if (isset($value[$language])){
-            $value = $value[$language];
-        }
-        return $value;
     }
 }

--- a/lib/ocopendata/src/Opencontent/Opendata/Api/EnvironmentSettings.php
+++ b/lib/ocopendata/src/Opencontent/Opendata/Api/EnvironmentSettings.php
@@ -4,13 +4,10 @@ namespace Opencontent\Opendata\Api;
 
 use Opencontent\Opendata\Api\Exception\OutOfRangeException;
 use Opencontent\Opendata\Api\Values\Content;
-use Opencontent\Opendata\Api\Values\ContentClass;
 use Opencontent\Opendata\Api\Values\SearchResults;
 use Opencontent\QueryLanguage\QueryBuilder;
 use Opencontent\Opendata\Api\Structs\ContentCreateStruct;
 use Opencontent\Opendata\Api\Structs\ContentUpdateStruct;
-
-
 
 class EnvironmentSettings
 {
@@ -86,7 +83,8 @@ class EnvironmentSettings
 
     /**
      * @param SearchResults $searchResults
-     *
+     * @param \ArrayObject $query
+     * @param QueryBuilder $builder
      * @return SearchResults
      */
     public function filterSearchResult(SearchResults $searchResults, \ArrayObject $query, QueryBuilder $builder)
@@ -100,7 +98,7 @@ class EnvironmentSettings
 
     /**
      * @param \ArrayObject $query
-     *
+     * @param QueryBuilder $builder
      * @return \ArrayObject
      */
     public function filterQuery(\ArrayObject $query, QueryBuilder $builder)
@@ -188,5 +186,8 @@ class EnvironmentSettings
         return $this->request;
     }
 
-
+    public function isDebug()
+    {
+        return $this->debug  == true;
+    }
 }

--- a/lib/ocopendata/src/Opencontent/Opendata/Api/Gateway.php
+++ b/lib/ocopendata/src/Opencontent/Opendata/Api/Gateway.php
@@ -1,11 +1,9 @@
 <?php
 
 namespace Opencontent\Opendata\Api;
+
 use Opencontent\Opendata\Api\Values\Content;
 use Opencontent\Opendata\Api\Exception\NotFoundException;
-use Opencontent\Opendata\Api\Exception\ForbiddenException;
-
-
 
 interface Gateway
 {

--- a/lib/ocopendata/src/Opencontent/Opendata/Api/Gateway/FileSystem.php
+++ b/lib/ocopendata/src/Opencontent/Opendata/Api/Gateway/FileSystem.php
@@ -2,7 +2,6 @@
 
 namespace Opencontent\Opendata\Api\Gateway;
 
-use Opencontent\Opendata\Api\Gateway;
 use Opencontent\Opendata\Api\Values\Content;
 use eZDir;
 use eZSys;

--- a/lib/ocopendata/src/Opencontent/Opendata/Api/Gateway/SolrStorage.php
+++ b/lib/ocopendata/src/Opencontent/Opendata/Api/Gateway/SolrStorage.php
@@ -10,8 +10,6 @@ use Opencontent\Opendata\Api\Gateway;
 use Opencontent\Opendata\Api\Values\Content;
 use Opencontent\Opendata\Api\Values\ContentData;
 use Opencontent\Opendata\Api\Values\Metadata;
-use Opencontent\Opendata\Api\Exception\NotFoundException;
-use Opencontent\Opendata\Api\Exception\ForbiddenException;
 
 class SolrStorage implements Gateway
 {

--- a/lib/ocopendata/src/Opencontent/Opendata/Api/QueryLanguage/EzFind/QueryBuilder.php
+++ b/lib/ocopendata/src/Opencontent/Opendata/Api/QueryLanguage/EzFind/QueryBuilder.php
@@ -4,7 +4,7 @@ namespace Opencontent\Opendata\Api\QueryLanguage\EzFind;
 
 use Opencontent\Opendata\Api\ClassRepository;
 use Opencontent\QueryLanguage\QueryBuilder as BaseQueryBuilder;
-
+use eZINI;
 
 class QueryBuilder extends BaseQueryBuilder
 {
@@ -67,6 +67,9 @@ class QueryBuilder extends BaseQueryBuilder
             $this->fields,
             array_keys( $availableFieldDefinitions )
         );
+        
+        $filtersList = (array)eZINI::instance( 'ezfind.ini' )->variable( 'ExtendedAttributeFilters', 'FiltersList' );
+        $this->parameters = array_merge($this->parameters, array_keys($filtersList));
 
         $this->tokenFactory = new TokenFactory(
             $this->fields,

--- a/lib/ocopendata/src/Opencontent/Opendata/Api/QueryLanguage/EzFind/SearchGateway.php
+++ b/lib/ocopendata/src/Opencontent/Opendata/Api/QueryLanguage/EzFind/SearchGateway.php
@@ -1,0 +1,303 @@
+<?php
+
+namespace Opencontent\Opendata\Api\QueryLanguage\EzFind;
+
+use Opencontent\Opendata\Api\ContentRepository;
+use Opencontent\Opendata\Api\Gateway\FileSystem;
+use Opencontent\Opendata\Api\Gateway\SolrStorage;
+use Opencontent\Opendata\Api\SearchGateway as BaseGateway;
+use Opencontent\Opendata\Api\Values\Content;
+use Opencontent\Opendata\Api\Values\Metadata;
+use Opencontent\Opendata\Api\Values\ContentData;
+use Opencontent\Opendata\Api\Values\ExtraData;
+use Opencontent\Opendata\Api\Values\SearchResults;
+use Opencontent\Opendata\Api\EnvironmentSettings;
+use Opencontent\QueryLanguage\QueryBuilderInterface;
+use Opencontent\Opendata\Api\SearchResultDecoratorInterface;
+use ArrayObject;
+use eZSolr;
+use ezfSearchResultInfo;
+use Exception;
+use eZINI;
+
+class SearchGateway implements BaseGateway
+{
+    /**
+     * @var EnvironmentSettings
+     */
+    private $environmentSettings;
+
+    /**
+     * @var QueryBuilder
+     */
+    private $queryBuilder;
+
+    public function search($query, $limitation = null)
+    {
+        $queryObject = $this->queryBuilder->instanceQuery($query);
+        $ezFindQueryObject = $queryObject->convert();
+
+        if (!$ezFindQueryObject instanceof ArrayObject) {
+            throw new \RuntimeException("Query builder did not return a valid query");
+        }
+
+        if ($ezFindQueryObject->getArrayCopy() === array("_query" => null) && !empty($query)){
+            throw new \RuntimeException("Inconsistent query");
+        }
+
+        $ezFindQueryObject = $this->environmentSettings->filterQuery($ezFindQueryObject, $this->queryBuilder);
+        $ezFindQuery = $ezFindQueryObject->getArrayCopy();
+
+        //$ezFindQuery['Filter'][] = ezfSolrDocumentFieldBase::generateMetaFieldName('installation_id') . ':' . eZSolr::installationID();
+        if (is_array($limitation) && empty($limitation)) {
+            $ezFindQuery['Filter'][] = \ezfSolrDocumentFieldBase::generateMetaFieldName('installation_id') . ':' . \eZSolr::installationID();
+        }
+        $ezFindQuery['Limitation'] = $limitation;
+        $ezFindQuery['AsObjects'] = false;
+        $ezFindQuery['FieldsToReturn'] = array(SolrStorage::getSolrIdentifier());
+
+        $filterFields = isset($ezFindQuery['_filterFields']) ? $ezFindQuery['_filterFields'] : null;
+        unset($ezFindQuery['_filterFields']);
+
+        $filterLanguages = isset($ezFindQuery['_filterLanguages']) ? $ezFindQuery['_filterLanguages'] : null;
+        unset($ezFindQuery['_filterLanguages']);
+
+        $solr = new eZSolr();
+        $rawResults = @$solr->search(
+            $ezFindQuery['_query'],
+            $ezFindQuery
+        );
+
+        $searchExtra = null;
+        if ($rawResults['SearchExtras'] instanceof ezfSearchResultInfo) {
+            if ($rawResults['SearchExtras']->attribute('hasError')) {
+                $error = $rawResults['SearchExtras']->attribute('error');
+                if (is_array($error)) {
+                    $error = (string)$error['msg'];
+                }
+                throw new \RuntimeException($error);
+            }
+
+            $searchExtra = SearchResultInfo::fromEzfSearchResultInfo($rawResults['SearchExtras']);
+        }
+
+        $searchResults = new SearchResults();
+        $filterFieldsResult = array();
+
+        if ($this->environmentSettings->isDebug()) {
+            $searchResults->query = array(
+                'string' => (string)$queryObject,
+                'eZFindQuery' => $ezFindQuery
+            );
+
+            if ($searchExtra instanceof SearchResultInfo) {
+                $searchResults->query['responseHeader'] = $searchExtra->attribute('responseHeader');
+            }
+        } else {
+            $searchResults->query = (string)$queryObject;
+        }
+
+        $searchResults->totalCount = (int)$rawResults['SearchCount'];
+
+        if (($ezFindQuery['SearchLimit'] + $ezFindQuery['SearchOffset']) < $searchResults->totalCount) {
+            $nextPageQuery = clone $queryObject;
+            $nextPageQuery->setParameter('offset', ($ezFindQuery['SearchLimit'] + $ezFindQuery['SearchOffset']));
+            $searchResults->nextPageQuery = (string)$nextPageQuery;
+        }
+
+        $fileSystemGateway = new FileSystem();
+        $contentRepository = new ContentRepository();
+        $contentRepository->setEnvironment($this->environmentSettings);
+
+        foreach ($rawResults['SearchResult'] as $resultItem) {
+            $id = isset($resultItem['meta_id_si']) ? $resultItem['meta_id_si'] : isset($resultItem['id_si']) ? $resultItem['id_si'] : $resultItem['id'];
+            try {
+                if (isset($resultItem['data_map']['opendatastorage'])) {
+                    $contentArray = $resultItem['data_map']['opendatastorage'];
+                    $content = new Content();
+                    $content->metadata = new Metadata((array)$contentArray['metadata']);
+                    $content->data = new ContentData((array)$contentArray['data']);
+                    if (isset($contentArray['extradata'])) {
+                        $content->extradata = new ExtraData((array)$contentArray['extradata']);
+                    }
+                } else {
+                    $content = $fileSystemGateway->loadContent((int)$id);
+                }
+
+                $ignorePolicies = false;
+                if (is_array($limitation)) {
+                    if (empty($limitation) || (isset($limitation['accessWord']) && $limitation['accessWord'] == 'yes')) {
+                        $ignorePolicies = true;
+                    }
+                }
+                $content = $contentRepository->read($content, $ignorePolicies);
+
+                if ($filterFields !== null) {
+                    $this->filterFields($filterFieldsResult, $content, $filterFields, $filterLanguages);
+                } else {
+                    $searchResults->searchHits[] = $content;
+                }
+
+            } catch (Exception $e) {
+                $content = new Content();
+                $content->metadata = new Metadata(array('id' => $id));
+                $content->data = new ContentData(
+                    array(
+                        '_error' => $e->getMessage(),
+                        '_rawresult' => $resultItem
+                    )
+                );
+            }
+        }
+
+        if (isset($ezFindQuery['Facet'])
+            && is_array($ezFindQuery['Facet'])
+            && !empty($ezFindQuery['Facet'])
+            && $searchExtra instanceof SearchResultInfo
+        ) {
+            $facets = array();
+            $facetResults = $searchExtra->attribute('facet_fields');
+            foreach ($ezFindQuery['Facet'] as $index => $facetDefinition) {
+                $facetResult = $facetResults[$index];
+                $facets[] = array(
+                    'name' => $facetDefinition['name'],
+                    'data' => $facetResult['countList']
+                );
+            }
+            $searchResults->facets = $facets;
+        }
+
+        $filtersList = (array)eZINI::instance('ezfind.ini')->variable('ExtendedAttributeFilters', 'FiltersList');
+        foreach (array_keys($filtersList) as $filterId){
+            $filter = \eZFindExtendedAttributeFilterFactory::getInstance($filterId);
+            if ($filter instanceof SearchResultDecoratorInterface){
+                $filter->decorate($searchResults, $rawResults);
+            }
+        }
+
+        if ($filterFields !== null) {
+            return $filterFieldsResult;
+        }
+
+        return $this->environmentSettings->filterSearchResult(
+            $searchResults,
+            $ezFindQueryObject,
+            $this->queryBuilder
+        );
+    }
+
+    public function getEnvironmentSettings()
+    {
+        return $this->environmentSettings;
+    }
+
+    public function setEnvironmentSettings(EnvironmentSettings $environmentSettings)
+    {
+        $this->environmentSettings = $environmentSettings;
+    }
+
+    /**
+     * @return QueryBuilderInterface
+     */
+    public function getQueryBuilder()
+    {
+        return $this->queryBuilder;
+    }
+
+    /**
+     * @param QueryBuilderInterface $queryBuilder
+     */
+    public function setQueryBuilder(QueryBuilderInterface $queryBuilder)
+    {
+        $this->queryBuilder = $queryBuilder;
+    }
+
+    private function filterFields(&$filterFieldsResult, $content, array $fields, array $languages = null)
+    {
+        $data = array();
+
+        if (!$languages) {
+            $languages = $content['metadata']['languages'];
+        }
+
+        if (count($fields) == 1) {
+            reset($fields);
+            $key = key($fields);
+            if (!is_numeric($key)) {
+                $value = $fields[$key];
+                $this->filterHashedFields($filterFieldsResult, $content, $key, $value, $languages);
+                return;
+            }
+        }
+
+        foreach ($fields as $field) {
+            $key = $this->getFieldKey($field);
+            $value = $this->getFieldValue($content, $field, $languages);
+            if (count($fields) == 1 && !$key) {
+                $data = $value;
+            } else {
+                if ($key) {
+                    $data[$key] = $value;
+                } else {
+                    $data[] = $value;
+                }
+            }
+        }
+        $filterFieldsResult[] = $data;
+    }
+
+    private function filterHashedFields(&$filterFieldsResult, $content, $key, $value, array $languages = null)
+    {
+        $filterFieldsResult[$this->getFieldValue($content, $key, $languages)] = $this->getFieldValue($content, $value, $languages);
+    }
+
+    private function getFieldIdentifier($field)
+    {
+        $fieldNameParts = explode(' as ', $field);
+
+        return $fieldNameParts[0];
+    }
+
+    private function getFieldKey($field)
+    {
+        $fieldNameParts = explode(' as ', $field);
+
+        return isset($fieldNameParts[1]) ? $fieldNameParts[1] : null;
+    }
+
+    private function getFieldValue($content, $field, $languages)
+    {
+        if (count($languages) == 1) {
+            $item = self::getValueFromDottedKey($content, $this->getFieldIdentifier($field), $languages[0]);
+        } else {
+            $item = array();
+            foreach ($languages as $language) {
+                $item[$language] = self::getValueFromDottedKey($content, $this->getFieldIdentifier($field), $language);
+            }
+        }
+
+        return $item;
+    }
+
+    private static function getValueFromDottedKey($array, $key, $language, $default = null)
+    {
+        $value = $default;
+        foreach (explode('.', $key) as $segment) {
+            if (isset($array[$segment])) {
+                $value = $array[$segment];
+                if (is_array($array[$segment])) {
+                    $array = $array[$segment];
+                    if (isset($array[$language]) && is_array($array[$language])) {
+                        $array = $array[$language];
+                    }
+                }
+            } else {
+                return $default;
+            }
+        }
+        if (isset($value[$language])) {
+            $value = $value[$language];
+        }
+        return $value;
+    }
+}

--- a/lib/ocopendata/src/Opencontent/Opendata/Api/QueryLanguage/EzFind/SearchResultInfo.php
+++ b/lib/ocopendata/src/Opencontent/Opendata/Api/QueryLanguage/EzFind/SearchResultInfo.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Opencontent\Opendata\Api\QueryLanguage\EzFind;
+
+use ezfSearchResultInfo;
+
+class SearchResultInfo extends ezfSearchResultInfo
+{
+    public static function fromEzfSearchResultInfo($info)
+    {
+        return new self($info->ResultArray);
+    }
+
+    public function attributes()
+    {
+        $attributes = parent::attributes();
+        $attributes[] = 'result';
+
+        return $attributes;
+    }
+
+    public function attribute($attr)
+    {
+        if ($attr == 'result') {
+
+            return $this->ResultArray;
+        }
+
+        return parent::attribute($attr);
+    }
+}

--- a/lib/ocopendata/src/Opencontent/Opendata/Api/QueryLanguage/EzFind/SentenceConverter.php
+++ b/lib/ocopendata/src/Opencontent/Opendata/Api/QueryLanguage/EzFind/SentenceConverter.php
@@ -73,6 +73,12 @@ class SentenceConverter
 
         if ( $field == 'q' )
         {
+            if (is_array($sentence->getValue())){
+                throw new Exception( "Value of query field (q) must be a string" );
+            }
+            if ($sentence->getOperator() !== '='){
+                throw new Exception( "Operator of query field (q) must be =" );
+            }
             $this->convertedQuery['_query'] = $this->cleanValue($sentence->stringValue());
             return null;
         }

--- a/lib/ocopendata/src/Opencontent/Opendata/Api/SearchGateway.php
+++ b/lib/ocopendata/src/Opencontent/Opendata/Api/SearchGateway.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Opencontent\Opendata\Api;
+
+use Opencontent\Opendata\Api\Values\SearchResults;
+use Opencontent\Opendata\Api\QueryLanguage;
+use Opencontent\QueryLanguage\QueryBuilderInterface;
+use Opencontent\Opendata\Api\EnvironmentSettings;
+
+interface SearchGateway
+{
+    /**
+     * @param mixed $query
+     * @param mixed|null $limitation
+     * @return SearchResults|mixed
+     */
+    public function search($query, $limitation = null);
+
+    /**
+     * @param EnvironmentSettings $environmentSettings
+     */
+    public function setEnvironmentSettings(EnvironmentSettings $environmentSettings);
+
+    /**
+     * @return EnvironmentSettings
+     */
+    public function getEnvironmentSettings();
+
+    /**
+     * @param QueryBuilderInterface $queryBuilder
+     */
+    public function setQueryBuilder(QueryBuilderInterface $queryBuilder);
+
+    /**
+     * @return QueryBuilderInterface
+     */
+    public function getQueryBuilder();
+}

--- a/lib/ocopendata/src/Opencontent/Opendata/Api/SearchResultDecoratorInterface.php
+++ b/lib/ocopendata/src/Opencontent/Opendata/Api/SearchResultDecoratorInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Opencontent\Opendata\Api;
+
+use Opencontent\Opendata\Api\Values\SearchResults;
+
+interface SearchResultDecoratorInterface
+{
+    public function decorate(SearchResults $searchResults, $rawResults);
+}

--- a/lib/ocopendata/src/Opencontent/Opendata/Api/Values/Content.php
+++ b/lib/ocopendata/src/Opencontent/Opendata/Api/Values/Content.php
@@ -12,7 +12,6 @@ use Opencontent\Opendata\Api\AttributeConverterLoader;
 use eZUser;
 use eZPreferences;
 use eZContentObjectTreeNode;
-use Opencontent\Opendata\Api\Gateway;
 use Opencontent\Opendata\GeoJson\Feature;
 use Opencontent\Opendata\GeoJson\Geometry;
 use Opencontent\Opendata\GeoJson\Properties;

--- a/lib/ocopendata/src/Opencontent/Opendata/Api/Values/SearchResults.php
+++ b/lib/ocopendata/src/Opencontent/Opendata/Api/Values/SearchResults.php
@@ -33,6 +33,7 @@ class SearchResults
      */
     public $facets = array();
 
+
     public function jsonSerialize()
     {
         $searchHits = array_map(function($value){
@@ -42,12 +43,14 @@ class SearchResults
             return $value;
         }, $this->searchHits);
 
-        return array(
+        $data = array(
           'query' => $this->query,
           'nextPageQuery' => $this->nextPageQuery,
           'totalCount' => $this->totalCount,
           'searchHits' => $searchHits,
           'facets' => $this->facets,
         );
+
+        return $data;
     }
 }

--- a/lib/ocopendata/src/Opencontent/Opendata/QueryLanguage/Builder/QueryBuilder.php
+++ b/lib/ocopendata/src/Opencontent/Opendata/QueryLanguage/Builder/QueryBuilder.php
@@ -5,7 +5,7 @@ namespace Opencontent\QueryLanguage;
 use Opencontent\QueryLanguage\Converter\QueryConverter;
 use Opencontent\QueryLanguage\Parser\TokenFactory;
 
-abstract class QueryBuilder
+abstract class QueryBuilder implements QueryBuilderInterface
 {
     public $fields = array();
 

--- a/lib/ocopendata/src/Opencontent/Opendata/QueryLanguage/Parser/ArrayValue.php
+++ b/lib/ocopendata/src/Opencontent/Opendata/QueryLanguage/Parser/ArrayValue.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Opencontent\QueryLanguage\Parser;
+
+class ArrayValue extends Value
+{
+    protected $data = array();
+
+    private $pendingKey;
+
+    public function __construct($data = array())
+    {
+        parent::__construct($data);
+    }
+
+    public function append($key, $value)
+    {
+        $key = trim($key);
+        $value = trim($value);
+
+        if ($key && $value) {
+            $this->data[$key] = $value;
+        }
+        if ($key && empty($value)) {
+            $this->pendingKey = $key;
+        }
+
+        if (!$key && $value) {
+            if ($this->pendingKey) {
+                $this->data[$this->pendingKey] = $value;
+                $this->pendingKey = null;
+            } else {
+                $this->data[] = $value;
+            }
+        }
+    }
+
+    public function toArray()
+    {
+        return $this->data;
+    }
+
+    public function __toString()
+    {
+        $value = $this->data;
+
+        if (is_array($value)) {
+            if (array_keys($value) === range(0, count($value) - 1)) {
+                $valueArray = array();
+                foreach ($value as $item){
+                    if (is_array($item)){
+                        $arrayValue = new ArrayValue($item);
+                        $valueArray[] = $arrayValue;
+                    }elseif (is_string($item)){
+                        $valueArray[] = $item;
+                    }
+                }
+                $string = '[' . implode(',', $valueArray) . ']';
+            } else {
+                $valueArray = array();
+                foreach ($value as $key => $item) {
+                    if (is_array($item)){
+                        $arrayValue = new ArrayValue($item);
+                        $valueArray[] = $key . '=>' . $arrayValue;
+                    }elseif (is_string($item)){
+                        $valueArray[] = $key . '=>' . $item;
+                    }
+
+                }
+                $string = '[' . implode(',', $valueArray) . ']';
+            }
+        } else {
+            $string = (string)$value;
+        }
+
+        return $string;
+    }
+}

--- a/lib/ocopendata/src/Opencontent/Opendata/QueryLanguage/Parser/Fragment.php
+++ b/lib/ocopendata/src/Opencontent/Opendata/QueryLanguage/Parser/Fragment.php
@@ -24,7 +24,7 @@ class Fragment implements ArrayAccess, Iterator, Countable
      */
     protected $tokenFactory;
 
-    public function __construct( $string = '', TokenFactory $tokenFactory )
+    public function __construct( $string, TokenFactory $tokenFactory )
     {
         $this->tokenFactory = $tokenFactory;
         $this->string = $string;

--- a/lib/ocopendata/src/Opencontent/Opendata/QueryLanguage/Parser/FragmentCollection.php
+++ b/lib/ocopendata/src/Opencontent/Opendata/QueryLanguage/Parser/FragmentCollection.php
@@ -25,6 +25,7 @@ class FragmentCollection implements Iterator, Countable
 
     /**
      * @param Fragment|FragmentCollection $fragment
+     * @throws Exception
      */
     public function add( $fragment )
     {

--- a/lib/ocopendata/src/Opencontent/Opendata/QueryLanguage/Parser/Parameter.php
+++ b/lib/ocopendata/src/Opencontent/Opendata/QueryLanguage/Parser/Parameter.php
@@ -4,8 +4,14 @@ namespace Opencontent\QueryLanguage\Parser;
 
 class Parameter extends Sentence
 {
+    /**
+     * @var Token
+     */
     protected $key;
 
+    /**
+     * @var Value
+     */
     protected $value;
 
     public function setKey( Token $data )
@@ -16,11 +22,6 @@ class Parameter extends Sentence
     public function getKey()
     {
         return $this->key;
-    }
-
-    public function setValue( Token $data )
-    {
-        $this->value = $data;
     }
 
     public function isValid()

--- a/lib/ocopendata/src/Opencontent/Opendata/QueryLanguage/Parser/ParenthesisSplitter.php
+++ b/lib/ocopendata/src/Opencontent/Opendata/QueryLanguage/Parser/ParenthesisSplitter.php
@@ -49,7 +49,8 @@ class ParenthesisSplitter
 
         if ( !$this->isBalanced() )
         {
-            throw new Exception( "Unbalanced parenthesis in \"$string\"" . mb_strlen( $string ) );
+            $string = $string ? " in \"$string\"" : '';
+            throw new Exception( "Unbalanced parenthesis {$open} or {$close}{$string}" );
         }
 
         $this->string = $originalString;

--- a/lib/ocopendata/src/Opencontent/Opendata/QueryLanguage/Parser/Value.php
+++ b/lib/ocopendata/src/Opencontent/Opendata/QueryLanguage/Parser/Value.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Opencontent\QueryLanguage\Parser;
+
+class Value
+{
+    protected $data = '';
+
+    public function __construct($data = null)
+    {
+        if (!empty($data)) {
+            $this->data = $data;
+        }
+    }
+
+    public function __toString()
+    {
+        return (string)$this->data;
+    }
+}

--- a/lib/ocopendata/src/Opencontent/Opendata/QueryLanguage/Parser/ValueParser.php
+++ b/lib/ocopendata/src/Opencontent/Opendata/QueryLanguage/Parser/ValueParser.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Opencontent\QueryLanguage\Parser;
+
+class ValueParser
+{
+    public static function parseString($string)
+    {
+        $string = trim($string);
+        if (strpos($string, '[') === 0) {
+            return self::parseArray($string);
+        }
+
+        return new Value($string);
+    }
+
+    protected static function parseArray($string)
+    {
+        $parenthesisParser = new ParenthesisSplitter($string, '[', ']');
+        $fragments = $parenthesisParser->run();
+        $value = new ArrayValue();
+        foreach ($fragments as $wrapper => $items) {
+            self::parseValueFragment($items, $value);
+        }
+        return $value;
+    }
+
+    protected static function parseValueFragment($items, ArrayValue $value)
+    {
+        $skipIndexItemList = array();
+        $rewriteIndexItems = array();
+        foreach ($items as $index => $item) {
+            if (in_array($index, $skipIndexItemList)){
+                continue;
+            }
+            if (isset($rewriteIndexItems[$index])){
+                $item = $rewriteIndexItems[$index];
+            }
+            if (is_string($item)) {
+                $parts = array();
+                if (strpos($item, "'") !== false) {
+                    $item = str_replace("\'", "$", $item);
+                    $cleanParts = explode("'", $item);
+
+                    foreach ($cleanParts as $cleanPart) {
+                        if ($cleanPart != '') {
+                            $cleanValue = trim($cleanPart);
+                            if ($cleanValue != ',') {
+                                $cleanValue = str_replace("$", "'", $cleanValue);
+                                $parts[] = "'$cleanValue'";
+                            }
+                        }
+                    }
+                } else {
+                    $parts = explode(",", $item);
+                    $parts = array_map('trim', $parts);
+                }
+
+                foreach ($parts as $part) {
+                    $hashSplit = explode('=>', $part);
+                    if (isset($hashSplit[1])) {
+                        $value->append($hashSplit[0], $hashSplit[1]);
+                    } else {
+                        $key = null;
+                        if ($part == 'raw' && is_array($items[$index+1]) && count($items[$index+1]) == 1){
+                            $part .= '[' . $items[$index+1][0] . ']';
+                            $skipIndexItemList[] = $index+1;
+                            if (isset($items[$index+2]) && is_string($items[$index+2])){
+                                $subParts = explode(",", $items[$index+2]);
+                                $subPart = array_shift($subParts);                                
+                                if (!empty($subPart)){
+                                    if (strpos($subPart, '=>') === 0){
+                                        $key = $part;
+                                        $part = trim(str_replace('=>', '', $subPart));  
+                                        if (count($subParts) == 0){   
+                                            $skipIndexItemList[] = $index+2;
+                                        }
+                                    }else{                                    
+                                        $part .= $subPart;
+                                    }
+                                }
+                                if (count($subParts) > 0){
+                                    $rewriteIndexItems[$index+2] = implode(', ', $subParts);
+                                }else{
+                                    $skipIndexItemList[] = $index+2;
+                                }
+                            }
+                        }
+                        $value->append($key, $part);
+                    }
+                }
+            } else {
+                $nestedValue = new ArrayValue();
+                self::parseValueFragment($item, $nestedValue);
+                $value->append(null, $nestedValue->toArray());
+            }
+        }
+    }
+
+}

--- a/lib/ocopendata/src/Opencontent/Opendata/QueryLanguage/QueryBuilderInterface.php
+++ b/lib/ocopendata/src/Opencontent/Opendata/QueryLanguage/QueryBuilderInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Opencontent\QueryLanguage;
+
+
+interface QueryBuilderInterface
+{
+    /**
+     * @param $string
+     * @return Query
+     */
+    public function instanceQuery($string);
+
+    /**
+     * @return Parser\TokenFactory
+     */
+    public function getTokenFactory();
+
+
+    /**
+     * @return Converter\QueryConverter;
+     */
+    public function getConverter();
+}

--- a/settings/ezfind.ini.append.php
+++ b/settings/ezfind.ini.append.php
@@ -4,4 +4,8 @@
 General[]=ezfIndexOpenDataStorage
 
 
+[ExtendedAttributeFilters]
+FiltersList[stats]=OpendataStatsExtendedAttributeFilter
+FiltersList[pivot]=OpendataPivotExtendedAttributeFilter
+FiltersList[facet_range]=OpendataRangeExtendedAttributeFilter
 */ ?>


### PR DESCRIPTION
 - aggiunge un parser dedicato per interpretare le parentesi quadre dei valori delle query ocql
 - il ParameterConvereter contempla gli [ExtendedAttributeFilters] FiltersList per creare la query di ezfind 
 - il ContentSearch usa una classe dedicata per eseguire la ricerca (interface SearchGateway)
 - il SearchGateway di default Opencontent\Opendata\Api\QueryLanguage\EzFind\SearchGateway decora il SearchResult se gli ExtendedAttributeFilters utilizzano l'interfaccia SearchResultDecoratorInterface
 - vengono inseriti tre ExtendedAttributeFilters di default: 
    - stats per https://wiki.apache.org/solr/StatsComponent
    - pivot per https://wiki.apache.org/solr/SimpleFacetParameters#Pivot_.28ie_Decision_Tree.29_Faceting-1
    - facet_range per esporre il range facet
 - la console mostra la query ezfind e i risultati offerti dai SearchResultDecoratorInterface
(usato in life franca e in ocpusher) 