### PR TITLE
Publish missing languages

### DIFF
--- a/lib/ocopendata/src/Opencontent/Opendata/Api/Exception/PublicationException.php
+++ b/lib/ocopendata/src/Opencontent/Opendata/Api/Exception/PublicationException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Opencontent\Opendata\Api\Exception;
+
+use Opencontent\Opendata\Api\Exception\BaseException;
+
+class PublicationException extends BaseException
+{
+}

--- a/lib/ocopendata/src/Opencontent/Opendata/Api/PublicationProcess.php
+++ b/lib/ocopendata/src/Opencontent/Opendata/Api/PublicationProcess.php
@@ -2,6 +2,7 @@
 
 namespace Opencontent\Opendata\Api;
 
+use Opencontent\Opendata\Api\Exception\PublicationException;
 use Opencontent\Opendata\Api\Structs\ContentCreateStruct;
 use Opencontent\Opendata\Api\Values\ContentSection;
 
@@ -152,14 +153,12 @@ class PublicationProcess
 
             return $id;
         } catch (\Exception $e) {
-print_r($e->getTraceAsString());
             if ($content->getRawContentObject()->attribute('current_version') == 1) {
                 $content->getRawContentObject()->remove();
             } else {
                 $content->getDraft()->removeThis();
             }
-            throw $e;
+            throw new PublicationException($e->getMessage(), $e->getCode(), $e);
         }
     }
-
 }


### PR DESCRIPTION
esempio: se, usando ocopendata_form, modifico un contenuto italiano da un siteaccess configurato in inglese, il PublicationProcess da errore
per risolvere l'errore è necessario passare al PublicationProcess anche le eventuali lingue già presenti nell'oggetto che il ContentUpdateStruct non contempla, copiandole dalla versione corrente